### PR TITLE
chore(deps): bump minimum version to 0.12.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,6 @@ rust-version = "1.74.1"
 bitcoin = { version = "0.32.2", features = ["serde", "std"], default-features = false }
 bitcoin_hashes = "0.20.0"
 clap = { version = "4.5.4", features = ["derive"] }
-esplora-client =  { version = "0.12.0", features = ["blocking-https"] }
+esplora-client =  { version = "0.12.3", features = ["blocking-https"] }
 serde_json = "1.0.116"
 hex = { package = "hex-conservative", version = "1", default-features = false, features = ["alloc"] }


### PR DESCRIPTION
Closes #7 


`get_blocks` was deprecated in favor of `get_block_infos` in 0.12.3. Specifying 0.12.0 allows Cargo to resolve 0.12.0–0.12.2, where the new method doesn't exist and breaks the build.